### PR TITLE
Remove extra qualification on member operator==

### DIFF
--- a/tensor.h
+++ b/tensor.h
@@ -115,7 +115,7 @@ public:
      * 
      * @return returns true if all their entries are "floating" equal
      */
-    bool Tensor::operator==(const Tensor& rhs) const;
+    bool operator==(const Tensor& rhs) const;
 
     /**
      * Operator overloading -


### PR DESCRIPTION
Removed extra qualification ‘Tensor::’ on member ‘operator==’.
Fixes `tensor.h:118:10: error: extra qualification ‘Tensor::’ on member ‘operator==’ [-fpermissive]`